### PR TITLE
completedAt not archivedAt

### DIFF
--- a/tap_anvil/schemas/submissions.json
+++ b/tap_anvil/schemas/submissions.json
@@ -94,7 +94,7 @@
         "string"
       ]
     },
-    "archivedAt": {
+    "completedAt": {
       "type": [
         "null",
         "string"


### PR DESCRIPTION
we have `createdAt`, `updatedAt` and `completedAt` for a `Submission`
but no `archivedAt`
https://www.useanvil.com/docs/api/graphql/reference/#definition-Submission