### PR TITLE
Fixes breaking Anvil GraphQL change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-anvil"
-version = "0.1.9"
+version = "0.1.10"
 description = "A Singer tap for Anvil, a tool for programmatically filling out PDF forms."
 authors = ["Kshitij Aranke <kshitij@aranke.org>"]
 keywords = ["singer", "tap", "anvil"]

--- a/tap_anvil/queries/welds.graphql
+++ b/tap_anvil/queries/welds.graphql
@@ -1,26 +1,32 @@
-query($slug: String!) {
+query WeldsQuery($slug: String!, $offset: Int = 0, $limit: Int = 100) {
     organization(organizationSlug: $slug) {
-        welds {
-            versionNumber
-            versionId
-            latestDraftVersionNumber
-            publishedNumber
-            publishedAt
-            hasUnpublishedChanges
-            id
-            eid
-            slug
-            name
-            visibility
-            config
-            hasSigners
-            signatureProviderType
-            availableSignatureProviderTypes
-            remainingSubmissions
-            createdAt
-            updatedAt
-            archivedAt
-            expiresAt
+        welds(offset: $offset, limit: $limit) {
+            page
+            pageCount
+            pageSize
+            rowCount
+            items {
+                versionNumber
+                versionId
+                latestDraftVersionNumber
+                publishedNumber
+                publishedAt
+                hasUnpublishedChanges
+                id
+                eid
+                slug
+                name
+                visibility
+                config
+                hasSigners
+                signatureProviderType
+                availableSignatureProviderTypes
+                remainingSubmissions
+                createdAt
+                updatedAt
+                archivedAt
+                expiresAt
+            }
         }
     }
 }

--- a/tap_anvil/streams.py
+++ b/tap_anvil/streams.py
@@ -27,20 +27,39 @@ class WeldsStream(AnvilStream):
 
     name = "welds"
     parent_stream_type = OrganizationsStream
-    jsonpath = "$.data.organization.welds[*]"
+    jsonpath = "$.data.organization.welds.items[*]"
     records_jsonpath: Any = jsonpath
     ignore_parent_replication_keys = True
+
+    def get_next_page_token(
+        self,
+        response: requests.Response,
+        previous_token: Optional[int],
+    ) -> Optional[int]:
+        """Handle pagination."""
+        data = response.json()
+        page = data["data"]["organization"]["welds"]
+
+        if data:
+            page_index = int(page["page"])
+            page_count = int(page["pageCount"])
+            page_size = int(page["pageSize"])
+            if page_index < page_count:
+                return page_index + page_size
+
+        return None
 
     def prepare_request_payload(
         self, context: Optional[Dict[str, Any]], next_page_token: Optional[int]
     ) -> Dict[str, Any]:
         """Inject GraphQL variables into payload."""
+        offset = next_page_token or 0
         assert context is not None
         slug = context["slug"]
 
         return {
             "query": self.query,
-            "variables": {"slug": slug},
+            "variables": {"slug": slug, "offset": offset},
         }
 
     def get_child_context(


### PR DESCRIPTION
# Summary

- Anvil's GraphQL API changed organization.welds from returning a flat array to a paginated response (with items, pageInfo, etc.) as of March 4, 2026. This broke the Singer tap and the Dagster pipeline has been failing since yesterday.
- Updated welds.graphql to request paginated fields (page, pageCount, pageSize, rowCount, items { ... }) with offset/limit variables
- Updated WeldsStream in streams.py to parse the paginated response ($.data.organization.welds.items[*]) and iterate through pages — matching the existing pagination pattern used by WeldDatasStream
- Bumped version from 0.1.9 to 0.1.10

## Context
- Anvil announced this breaking change in October 2025. Their rep confirmed Vouch is actively using organization.welds without pagination. The usage was traced to this Singer tap (not the specialty-* services, which query individual welds by EID and are unaffected).
- The anvil-singer-snowflake setup script also needs to be updated from @0.1.7 to @0.1.10 