### PR TITLE
chore: pin and harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   bump-version:
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
@@ -12,17 +15,17 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
           fetch-depth: 0
       - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@0.14.1
+        uses: commitizen-tools/commitizen-action@8510ee6f03058ad64c5f73447ce2a2589d752114 # 0.14.1
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: body.md
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           body_path: "body.md"
           tag_name: ${{ env.REVISION }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -18,15 +18,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,16 +2,21 @@ name: Test
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   mypy:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: Install Poetry
       run: pipx install poetry
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: '3.9'
         cache: 'poetry'
@@ -29,11 +34,13 @@ jobs:
     env:
       TAP_ANVIL_API_KEY: ${{ secrets.ANVIL_API_KEY }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: Install Poetry
       run: pipx install poetry
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
@@ -42,4 +49,4 @@ jobs:
     - name: Run pytest
       run: poetry run pytest --cov=tap_anvil tests/ --cov-report=xml
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3


### PR DESCRIPTION
## Summary
- pin all referenced GitHub Actions to full SHAs
- add explicit permissions for test and release-related workflows
- disable persisted checkout credentials on read-only workflows
- keep existing CodeQL permissions shape while pinning the actions

## Why
This repo was not the highest-risk case for the March 19–22 window, but it still used mutable action references. This change proactively hardens the workflows and removes unnecessary drift.

## Validation
- YAML parsed locally
- `git diff --check` passed